### PR TITLE
Add scopes support and example

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Install [`m4tthumphrey/php-gitlab-api`](https://packagist.org/packages/m4tthumph
 Gitlab API after authentication. Either connect manually:
 
 ```php
-$client = new \Gitlab\Client('https://my.gitlab.url/api/v3/');
+$client = new \Gitlab\Client('https://my.gitlab.url/api/v4/');
 $client->authenticate($token->getToken(), \Gitlab\Client::AUTH_OAUTH_TOKEN);
 ```
 Or call the `getApiClient` method on `GitlabResourceOwner` which does the same implicitly.

--- a/README.md
+++ b/README.md
@@ -74,6 +74,21 @@ if (!isset($_GET['code'])) {
 }
 ```
 
+### Managing Scopes
+
+When creating your GitLab authorization URL, you can specify the state and scopes your application may authorize.
+
+```php
+$options = [
+    'state' => 'OPTIONAL_CUSTOM_CONFIGURED_STATE',
+    'scope' => ['read_user','openid'] // array or string
+];
+
+$authorizationUrl = $provider->getAuthorizationUrl($options);
+```
+If neither are defined, the provider will utilize internal defaults ```'api'```.
+
+
 ### Performing API calls
 
 Install [`m4tthumphrey/php-gitlab-api`](https://packagist.org/packages/m4tthumphrey/php-gitlab-api) to interact with the

--- a/src/Provider/Gitlab.php
+++ b/src/Provider/Gitlab.php
@@ -29,6 +29,8 @@ class Gitlab extends AbstractProvider
     const PATH_API_USER = '/api/v4/user';
     const PATH_AUTHORIZE = '/oauth/authorize';
     const PATH_TOKEN = '/oauth/token';
+    const DEFAULT_SCOPE = 'api';
+    const SCOPE_SEPARATOR = ' ';
 
     /** @var string */
     public $domain = 'https://gitlab.com';
@@ -91,7 +93,7 @@ class Gitlab extends AbstractProvider
      */
     protected function getDefaultScopes()
     {
-        return ['api'];
+        return [self::DEFAULT_SCOPE];
     }
 
     /**
@@ -99,10 +101,8 @@ class Gitlab extends AbstractProvider
      */
     protected function getScopeSeparator()
     {
-        return ' ';
+        return self::SCOPE_SEPARATOR;
     }
-
-
 
     /**
      * Check a provider response for errors.

--- a/src/Provider/Gitlab.php
+++ b/src/Provider/Gitlab.php
@@ -82,16 +82,27 @@ class Gitlab extends AbstractProvider
     }
 
     /**
-     * Get the default scopes used by this provider.
+     * Get the default scopes used by GitLab.
+     * Current scopes are 'api', 'read_user', 'openid'
      *
-     * This returns an empty array as Gitlab does not support scopes yet.
+     * This returns an array with 'api' scope as default.
      *
      * @return array
      */
     protected function getDefaultScopes()
     {
-        return [];
+        return ['api'];
     }
+
+    /**
+     * GitLab uses a space to separate scopes
+     */
+    protected function getScopeSeparator()
+    {
+        return ' ';
+    }
+
+
 
     /**
      * Check a provider response for errors.

--- a/test/src/Provider/GitlabTest.php
+++ b/test/src/Provider/GitlabTest.php
@@ -65,7 +65,7 @@ class GitlabTest extends TestCase
 
         $url = $this->provider->getAuthorizationUrl($options);
 
-        $this->assertContains(rawurlencode(implode(' ', $options['scope'])), $url);
+        $this->assertContains(rawurlencode(implode(Gitlab::SCOPE_SEPARATOR, $options['scope'])), $url);
     }
 
     public function testGetAuthorizationUrl()

--- a/test/src/Provider/GitlabTest.php
+++ b/test/src/Provider/GitlabTest.php
@@ -65,7 +65,7 @@ class GitlabTest extends TestCase
 
         $url = $this->provider->getAuthorizationUrl($options);
 
-        $this->assertContains(urlencode(implode(',', $options['scope'])), $url);
+        $this->assertContains(rawurlencode(implode(' ', $options['scope'])), $url);
     }
 
     public function testGetAuthorizationUrl()


### PR DESCRIPTION
GitLab now supports the following scopes:

![screen shot 2017-10-31 at 11 54 07 am](https://user-images.githubusercontent.com/2364606/32234065-3eddc008-be32-11e7-89a3-6a26f4e3c6fa.png)
