### PR TITLE
Mark conflict for league/oauth2-client 2.4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,6 +41,9 @@
             "Omines\\OAuth2\\Client\\Test\\": "test/src/"
         }
     },
+    "conflict": {
+        "league/oauth2-client": "2.4.0"
+    },
     "extra": {
         "branch-alias": {
             "dev-master": "3.x-dev"


### PR DESCRIPTION
There are some changes in argument types in AbstractProvider in version 2.4.0 that break inherited classes. They are corrected in 2.4.1

Fixes #6 